### PR TITLE
fix the requirement version for building

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ mock==2.0.0
 requests[security]>=2.18.4
 pycoin==0.80
 pyld>=1.0.3
-pysha3>=1.0.2
+pysha3>=1.0b1
 python-bitcoinlib>=0.10.1
 tox>=3.0.0
 jsonschema<3.0.0


### PR DESCRIPTION
I just fix the pysha version when you build cert-issuer with dockerfile.
As you can see this below the link,  this revision will not affect your downstream projects now.

https://github.com/blockchain-certificates/cert-issuer/issues/145